### PR TITLE
allow switching to system audio from microphone and back when stream source changes

### DIFF
--- a/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/WebRTCClient.java
+++ b/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/WebRTCClient.java
@@ -158,6 +158,7 @@ public class WebRTCClient implements IWebRTCClient, AntMediaSignallingEvents, ID
     private String streamName = "";
     private String viewerInfo = "";
     private String currentSource;
+
     private boolean screenPermissionNeeded = true;
 
     public MediaProjection mediaProjection;
@@ -241,6 +242,7 @@ public class WebRTCClient implements IWebRTCClient, AntMediaSignallingEvents, ID
     // recorded audio samples to an output file.
     @androidx.annotation.Nullable
     private RecordedAudioToFileController saveRecordedAudioToFile;
+
 
     @androidx.annotation.Nullable
     public AudioDeviceModule adm;
@@ -918,6 +920,8 @@ public class WebRTCClient implements IWebRTCClient, AntMediaSignallingEvents, ID
         openFrontCamera = !openFrontCamera;
         executor.execute(this ::switchCameraInternal);
     }
+
+
 
     @Override
     public void onCameraSwitch() {
@@ -1628,6 +1632,7 @@ public class WebRTCClient implements IWebRTCClient, AntMediaSignallingEvents, ID
 
         adm = createJavaAudioDevice();
 
+
         // Create peer connection factory.
         if (options != null) {
             Log.d(TAG, "Factory networkIgnoreMask option: " + options.networkIgnoreMask);
@@ -2145,6 +2150,7 @@ public class WebRTCClient implements IWebRTCClient, AntMediaSignallingEvents, ID
     @androidx.annotation.Nullable
     private VideoTrack createVideoTrack(VideoCapturer capturer) {
         if (localVideoTrack == null && capturer != null) {
+
             surfaceTextureHelper =
                     SurfaceTextureHelper.create("CaptureThread", eglBase.getEglBaseContext());
             videoSource = factory.createVideoSource(capturer.isScreencast());
@@ -2470,4 +2476,43 @@ public class WebRTCClient implements IWebRTCClient, AntMediaSignallingEvents, ID
         this.signalingParameters = signalingParameters;
     }
 
+    @androidx.annotation.Nullable
+    public AudioDeviceModule getAdm() {
+        return adm;
+    }
+
+    public void restartAdmRecording(){
+        stopAdmRecording();
+        //if media projection is null, microphone will be used to record audio.
+        setMediaProjection(null);
+        //media projection is set to null thus it will capture microphone.
+        createAudioRecord();
+        startRecording();
+    }
+
+    public void createAudioRecord(){
+        if(adm != null){
+            adm.createAudioRecord();
+        }
+    }
+
+    public void startRecording(){
+        if(adm != null){
+            adm.startRecording();
+        }
+    }
+
+    public void stopAdmRecording(){
+        if(adm != null){
+            adm.stopRecording();
+        }
+    }
+
+    public boolean isScreenPermissionNeeded() {
+        return screenPermissionNeeded;
+    }
+
+    public void setScreenPermissionNeeded(boolean screenPermissionNeeded) {
+        this.screenPermissionNeeded = screenPermissionNeeded;
+    }
 }

--- a/webrtc-android-framework/src/main/java/org/webrtc/audio/AudioDeviceModule.java
+++ b/webrtc-android-framework/src/main/java/org/webrtc/audio/AudioDeviceModule.java
@@ -41,4 +41,10 @@ public interface AudioDeviceModule {
   /** Set media projection for the audio record. */
   void setMediaProjection(MediaProjection mediaProjection);
 
+  void createAudioRecord();
+
+  void startRecording();
+
+  void stopRecording();
+
 }

--- a/webrtc-android-framework/src/main/java/org/webrtc/audio/JavaAudioDeviceModule.java
+++ b/webrtc-android-framework/src/main/java/org/webrtc/audio/JavaAudioDeviceModule.java
@@ -14,10 +14,13 @@ import android.content.Context;
 import android.media.AudioAttributes;
 import android.media.AudioDeviceInfo;
 import android.media.AudioManager;
+import android.media.MediaRecorder;
 import android.media.projection.MediaProjection;
 import android.os.Build;
 import androidx.annotation.RequiresApi;
 import java.util.concurrent.ScheduledExecutorService;
+
+import org.webrtc.AudioSource;
 import org.webrtc.JniCommon;
 import org.webrtc.Logging;
 
@@ -439,5 +442,21 @@ public class JavaAudioDeviceModule implements AudioDeviceModule {
   public void setMediaProjection(MediaProjection mediaProjection){
     audioInput.setMediaProjection(mediaProjection);
   }
+
+  @Override
+  public void createAudioRecord() {
+    audioInput.createAudioRecord();
+  }
+
+  @Override
+  public void startRecording() {
+    audioInput.startRecording();
+  }
+
+  @Override
+  public void stopRecording() {
+    audioInput.stopRecording();
+  }
+
 
 }

--- a/webrtc-android-framework/src/main/java/org/webrtc/audio/LegacyAudioDeviceModule.java
+++ b/webrtc-android-framework/src/main/java/org/webrtc/audio/LegacyAudioDeviceModule.java
@@ -50,4 +50,19 @@ public class LegacyAudioDeviceModule implements AudioDeviceModule {
   public void setMediaProjection(MediaProjection mediaProjection) {
 
   }
+
+  @Override
+  public void createAudioRecord() {
+
+  }
+
+  @Override
+  public void startRecording() {
+
+  }
+
+  @Override
+  public void stopRecording() {
+
+  }
 }

--- a/webrtc-android-framework/src/test/java/io/antmedia/webrtcandroidframework/WebRTCClientTest.java
+++ b/webrtc-android-framework/src/test/java/io/antmedia/webrtcandroidframework/WebRTCClientTest.java
@@ -30,7 +30,6 @@ import android.util.DisplayMetrics;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
-import org.awaitility.Awaitility;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;


### PR DESCRIPTION
https://github.com/ant-media/Ant-Media-Server/issues/2940

Enable switching between system audio and microphone during stream source change

This PR enables switching of audio sources during streaming. When a user switches from the camera to screen sharing, the audio recording automatically switches from the microphone to system audio. Similarly, when switching from screen sharing to the camera, the audio switches back from system audio to the microphone.



