### PR TITLE
initialize audio manager for play 

### DIFF
--- a/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/WebRTCClient.java
+++ b/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/WebRTCClient.java
@@ -558,7 +558,7 @@ public class WebRTCClient implements IWebRTCClient, AntMediaSignallingEvents, ID
 
 
 
-    private void initializeParameters() {
+    public void initializeParameters() {
         loopback = intent.getBooleanExtra(CallActivity.EXTRA_LOOPBACK, false);
         tracing = intent.getBooleanExtra(CallActivity.EXTRA_TRACING, false);
 
@@ -2444,6 +2444,10 @@ public class WebRTCClient implements IWebRTCClient, AntMediaSignallingEvents, ID
 
     public boolean getVideoCallEnabled() {
         return videoCallEnabled;
+    }
+
+    public boolean getAudioCallEnabled() {
+        return audioCallEnabled;
     }
 
     public String getCurrentSource() {

--- a/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/WebRTCClient.java
+++ b/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/WebRTCClient.java
@@ -14,6 +14,7 @@ import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.media.AudioDeviceInfo;
 import android.media.projection.MediaProjection;
 import android.media.projection.MediaProjectionManager;
 import android.os.Build;
@@ -602,10 +603,17 @@ public class WebRTCClient implements IWebRTCClient, AntMediaSignallingEvents, ID
 
         videoCallEnabled = intent.getBooleanExtra(CallActivity.EXTRA_VIDEO_CALL, true);
 
-        if (streamMode.equals(MODE_PLAY) || streamMode.equals(MODE_MULTI_TRACK_PLAY) || isDataChannelOnly()) {
+        if (isDataChannelOnly()) {
             videoCallEnabled = false;
             audioCallEnabled = false;
         }
+
+        if(streamMode.equals(MODE_PLAY) || streamMode.equals(MODE_MULTI_TRACK_PLAY)){
+            videoCallEnabled = false;
+            audioCallEnabled = true;
+        }
+
+
 
         hwCodecAcceleration = intent.getBooleanExtra(CallActivity.EXTRA_HWCODEC_ENABLED, true);
         videoFlexfecEnabled = intent.getBooleanExtra(CallActivity.EXTRA_FLEXFEC_ENABLED, false);
@@ -716,6 +724,7 @@ public class WebRTCClient implements IWebRTCClient, AntMediaSignallingEvents, ID
             });
         }
     }
+
 
     public void initializeVideoCapturer() {
         // if video capture is null or disposed, we should recreate it.

--- a/webrtc-android-framework/src/test/java/io/antmedia/webrtcandroidframework/WebRTCClientTest.java
+++ b/webrtc-android-framework/src/test/java/io/antmedia/webrtcandroidframework/WebRTCClientTest.java
@@ -440,5 +440,39 @@ public class WebRTCClientTest {
         verify(wsHandler, timeout(1000)).disconnect(true);
     }
 
+    @Test
+    public void testAudioVideoEnablement() {
+        IWebRTCListener listener = Mockito.mock(IWebRTCListener.class);
+        Context context = Mockito.mock(Context.class);
+        WebRTCClient webRTCClient = Mockito.spy(new WebRTCClient(listener, context));
+
+        when(context.getString(R.string.pref_maxvideobitratevalue_default)).thenReturn("500");
+        when(context.getString(R.string.pref_startaudiobitratevalue_default)).thenReturn("500");
+
+        Intent intent = Mockito.mock(Intent.class);
+
+        webRTCClient.setStreamMode(WebRTCClient.MODE_PLAY);
+        webRTCClient.initializeParameters();
+        assertEquals(false, webRTCClient.getVideoCallEnabled());
+        assertEquals(true, webRTCClient.getAudioCallEnabled());
+
+        webRTCClient.setVideoEnabled(false);
+        webRTCClient.setAudioEnabled(false);
+
+        webRTCClient.setStreamMode(WebRTCClient.MODE_MULTI_TRACK_PLAY);
+        webRTCClient.initializeParameters();
+        assertEquals(false, webRTCClient.getVideoCallEnabled());
+        assertEquals(true, webRTCClient.getAudioCallEnabled());
+
+        webRTCClient.setVideoEnabled(false);
+        webRTCClient.setAudioEnabled(false);
+
+        webRTCClient.setStreamMode("some other mode");
+        webRTCClient.initializeParameters();
+        assertEquals(false, webRTCClient.getVideoCallEnabled());
+        assertEquals(false, webRTCClient.getAudioCallEnabled());
+
+
+    }
 
 }

--- a/webrtc-android-sample-app/src/main/java/io/antmedia/webrtc_android_sample_app/ScreenCaptureActivity.java
+++ b/webrtc-android-sample-app/src/main/java/io/antmedia/webrtc_android_sample_app/ScreenCaptureActivity.java
@@ -12,6 +12,7 @@ import android.media.projection.MediaProjectionManager;
 import android.os.Build;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
+import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.View;
 import android.view.Window;

--- a/webrtc-android-sample-app/src/main/res/layout/activity_multitrack.xml
+++ b/webrtc-android-sample-app/src/main/res/layout/activity_multitrack.xml
@@ -41,6 +41,7 @@
     <EditText
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:background="#ffffff"
         android:id="@+id/stream_id_edittext"
         android:layout_above="@id/start_streaming_button"/>
 

--- a/webrtc-android-sample-app/src/main/res/values/strings.xml
+++ b/webrtc-android-sample-app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">And Media WebRTC Sample App</string>
+    <string name="app_name">Ant Media WebRTC Sample App</string>
     <string name="start">Start</string>
     <string name="write_something">Write a Message!</string>
     <string name="title_activity_settings">Settings</string>


### PR DESCRIPTION
https://github.com/ant-media/Ant-Media-Server/issues/5084
The audio manager was not initialized on the WebRTC client when the mode is set to "play." This pull request initializes the audio manager if the mode is "play," thereby enabling the use of the main phone speakers for incoming audio during playback. Prior to this change, the call speakers were used, resulting in low audio. Additionally, this pull request includes some other minor fixes, such as correcting a typo in the sample app name.





