### PR TITLE
added mode param to joinRoom command package

### DIFF
--- a/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/ConferenceManager.java
+++ b/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/ConferenceManager.java
@@ -88,7 +88,7 @@ public class ConferenceManager implements AntMediaSignallingEvents, IDataChannel
 
     public void joinTheConference() {
         initWebSocketHandler();
-        wsHandler.joinToConferenceRoom(roomName, streamId);
+        wsHandler.joinToConferenceRoom(roomName, streamId, null);
     }
 
     private void initWebSocketHandler() {

--- a/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/MultitrackConferenceManager.java
+++ b/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/MultitrackConferenceManager.java
@@ -154,7 +154,7 @@ public class MultitrackConferenceManager implements AntMediaSignallingEvents, ID
     }
 
     public void joinTheConference() {
-        wsHandler.joinToConferenceRoom(roomName, streamId);
+        wsHandler.joinToConferenceRoom(roomName, streamId, WebSocketConstants.MULTI_TRACK);
     }
 
     public void initWebSocketHandler() {

--- a/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/WebSocketConstants.java
+++ b/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/WebSocketConstants.java
@@ -420,4 +420,6 @@ public class WebSocketConstants {
      */
     public static final String MAIN_TRACK = "mainTrack";
 
+    public static final String MULTI_TRACK = "multitrack";
+
 }

--- a/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/WebSocketHandler.java
+++ b/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/WebSocketHandler.java
@@ -453,13 +453,16 @@ public class WebSocketHandler implements WebSocket.WebSocketConnectionObserver {
         }
     }
 
-    public void joinToConferenceRoom(String roomName, String streamId) {
+    public void joinToConferenceRoom(String roomName, String streamId, String mode) {
         checkIfCalledOnValidThread();
         JSONObject json = new JSONObject();
         try {
             json.put(WebSocketConstants.COMMAND, WebSocketConstants.JOIN_ROOM_COMMAND);
             json.put(WebSocketConstants.ROOM, roomName);
             json.put(WebSocketConstants.STREAM_ID, streamId);
+            if (mode != null) {
+                json.put(WebSocketConstants.MODE, mode);
+            }
             sendTextMessage(json.toString());
         } catch (JSONException e) {
             Log.e(TAG, "Connect to conference room JSON error: " + e.getMessage());

--- a/webrtc-android-framework/src/test/java/io/antmedia/webrtcandroidframework/MultitrackConferenceManagerTest.java
+++ b/webrtc-android-framework/src/test/java/io/antmedia/webrtcandroidframework/MultitrackConferenceManagerTest.java
@@ -70,7 +70,7 @@ public class MultitrackConferenceManagerTest {
         conferenceManager.joinTheConference();
 
         // Verify that the joinToConferenceRoom method of WebSocketHandler is called with the correct arguments
-        verify(wsHandler).joinToConferenceRoom("roomName", "streamId");
+        verify(wsHandler).joinToConferenceRoom("roomName", "streamId", null);
     }
 
     @Test


### PR DESCRIPTION
We noticed that when the Client SDK sends the JointRooom command to the server, unlike the JS SDK, there is no Mode parameter that determines the conference mode, although the default, as we understand it, is “multi-track”. To make the Android SDK consistent to the JS SDK, we suggest adding this mode setting.
