### PR TITLE
allow the client app to set custom stun-server

### DIFF
--- a/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/WebRTCClient.java
+++ b/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/WebRTCClient.java
@@ -683,7 +683,11 @@ public class WebRTCClient implements IWebRTCClient, AntMediaSignallingEvents, ID
 
         iceConnected = false;
         signalingParameters = null;
-        iceServers.add(new PeerConnection.IceServer(stunServerUri));
+        if (intent != null && intent.getStringExtra(CallActivity.EXTRA_STUN_SERVER) != null) {
+            iceServers.add(new PeerConnection.IceServer(intent.getStringExtra(CallActivity.EXTRA_STUN_SERVER)));
+        } else {
+            iceServers.add(new PeerConnection.IceServer(stunServerUri));
+        }
 
         if(streamMode.equals(MODE_MULTI_TRACK_PLAY) && trackCheckerTask == null) {
             trackCheckerTask = new TrackCheckTask();

--- a/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/apprtc/CallActivity.java
+++ b/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/apprtc/CallActivity.java
@@ -66,6 +66,8 @@ import io.antmedia.webrtcandroidframework.R;
 public class CallActivity  {
   private static final String TAG = "CallRTCClient";
 
+  public static final String EXTRA_STUN_SERVER = "org.appspot.apprtc.STUN_SERVER";
+
   public static final String EXTRA_ROOMID = "org.appspot.apprtc.ROOMID";
   public static final String EXTRA_URLPARAMETERS = "org.appspot.apprtc.URLPARAMETERS";
   public static final String EXTRA_LOOPBACK = "org.appspot.apprtc.LOOPBACK";


### PR DESCRIPTION
There is no way to add own STUN server.

We noticed that at the moment Android SDK does not allow to install own STUN server from client code. We are sending a pull request to allow custom STUN server setup via the intent argument in the WebRTCClient.init method, following your SDK development logic.