### PR TITLE
added handler for event no_active_streams_in_room

### DIFF
--- a/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/WebSocketConstants.java
+++ b/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/WebSocketConstants.java
@@ -66,6 +66,8 @@ public class WebSocketConstants {
 
     public static final String NO_STREAM_EXIST = "no_stream_exist";
 
+    public static final String NO_ACTIVE_STREAMS_IN_ROOM = "no_active_streams_in_room";
+
     public static final String JOIN_ROOM_COMMAND = "joinRoom";
 
     public static final String ROOM = "room";

--- a/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/WebSocketHandler.java
+++ b/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/WebSocketHandler.java
@@ -238,6 +238,10 @@ public class WebSocketHandler implements WebSocket.WebSocketConnectionObserver {
                     signallingListener.noStreamExistsToPlay(streamId);
                     //disconnect(true);
                 }
+
+                if (definition.equals(WebSocketConstants.NO_ACTIVE_STREAMS_IN_ROOM)) {
+                    signallingListener.noStreamExistsToPlay(streamId);
+                }
                 if(definition.equals(WebSocketConstants.STREAM_ID_IN_USE)){
                     signallingListener.streamIdInUse(streamId);
                     disconnect(true);


### PR DESCRIPTION
If there are no members in the room to notify the user that no one is in the room, it would be logically correct to send an empty "streamList" in the "roomInformation" command - {"ATTR_ROOM_NAME":"room1","streams":[],"streamList " :[],"command":"roomInformation","room":"room1".

But nontheless the server sends an "error" command with "no_active_streams_in_room" definition {"definition":"no_active_streams_in_room","command":"error","room":"room1"}. Hance Client SDK should process this error command.