### PR TITLE
Added an onConnected event to AntMediaSignallingEvents

### DIFF
--- a/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/AntMediaSignallingEvents.java
+++ b/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/AntMediaSignallingEvents.java
@@ -81,6 +81,11 @@ public interface AntMediaSignallingEvents {
     void onDisconnected();
 
     /**
+     * It's called when websocket connection is connected
+     */
+    void onConnected();
+
+    /**
      * It's called in responde the getTrackList methods
      * @param tracks
      */

--- a/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/ConferenceManager.java
+++ b/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/ConferenceManager.java
@@ -326,6 +326,11 @@ public class ConferenceManager implements AntMediaSignallingEvents, IDataChannel
     }
 
     @Override
+    public void onConnected() {
+
+    }
+
+    @Override
     public void onTrackList(String[] tracks) {
 
     }

--- a/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/MultitrackConferenceManager.java
+++ b/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/MultitrackConferenceManager.java
@@ -345,6 +345,11 @@ public class MultitrackConferenceManager implements AntMediaSignallingEvents, ID
     }
 
     @Override
+    public void onConnected() {
+
+    }
+
+    @Override
     public void onTrackList(String[] tracks) {
         //add own stream id  to the list as !+streamId
         ArrayList<String> trackList = new ArrayList<>();

--- a/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/WebSocketHandler.java
+++ b/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/WebSocketHandler.java
@@ -98,7 +98,7 @@ public class WebSocketHandler implements WebSocket.WebSocketConnectionObserver {
 
     @Override
     public void onOpen() {
-
+        signallingListener.onConnected();
     }
 
     @Override


### PR DESCRIPTION
We suggest to add onConnected method in SDK to notify Client Code that WebSocket Connection is established.  Called when ws-connection is opened. The client app can process it based on its requirements.