### PR TITLE
allow the client app to set metaData for stream and send it by publish

### DIFF
--- a/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/IWebRTCClient.java
+++ b/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/IWebRTCClient.java
@@ -155,5 +155,11 @@ public interface IWebRTCClient extends CallFragment.OnCallEvents {
      */
     void setStreamName(String streamName);
 
+    /**
+     * This is used to set the additional metaData of WebRTC stream
+     * @param metaData: any string
+     */
+    void setStreamMetaData(String metaData);
+
 
 }

--- a/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/WebRTCClient.java
+++ b/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/WebRTCClient.java
@@ -190,6 +190,7 @@ public class WebRTCClient implements IWebRTCClient, AntMediaSignallingEvents, ID
     private String subscriberId = "";
     private String subscriberCode = "";
     private String streamName = "";
+    private String streamMetaData = "";
     private String viewerInfo = "";
     private String currentSource;
     private boolean screenPermissionNeeded = true;
@@ -1140,7 +1141,7 @@ public class WebRTCClient implements IWebRTCClient, AntMediaSignallingEvents, ID
     private void startCall() {
         Log.d(TAG, this.context.getString(R.string.connecting_to, url));
         if (streamMode.equals(IWebRTCClient.MODE_PUBLISH)) {
-            publish(streamId, token, videoCallEnabled, audioCallEnabled, subscriberId, subscriberCode, streamName, mainTrackId);
+            publish(streamId, token, videoCallEnabled, audioCallEnabled, subscriberId, subscriberCode, streamName, mainTrackId, streamMetaData);
         }
         else if (streamMode.equals(IWebRTCClient.MODE_PLAY)) {
             play(streamId, token, null, subscriberId, subscriberCode, viewerInfo);
@@ -1153,8 +1154,8 @@ public class WebRTCClient implements IWebRTCClient, AntMediaSignallingEvents, ID
         }
     }
 
-    private void publish(String roomId, String token, boolean videoCallEnabled, boolean audioCallEnabled, String subscriberId, String subscriberCode, String streamName, String mainTrackId) {
-        wsHandler.startPublish(roomId, token, videoCallEnabled, audioCallEnabled, subscriberId, subscriberCode, streamName, mainTrackId);
+    private void publish(String roomId, String token, boolean videoCallEnabled, boolean audioCallEnabled, String subscriberId, String subscriberCode, String streamName, String mainTrackId, String streamMetaData) {
+        wsHandler.startPublish(roomId, token, videoCallEnabled, audioCallEnabled, subscriberId, subscriberCode, streamName, mainTrackId, streamMetaData);
     }
 
     public void play(String streamId, String token, String[] tracks) {
@@ -1722,6 +1723,11 @@ public class WebRTCClient implements IWebRTCClient, AntMediaSignallingEvents, ID
     @Override
     public void setStreamName(String streamName) {
         this.streamName = streamName;
+    }
+
+    @Override
+    public void setStreamMetaData(String streamMetaData) {
+        this.streamMetaData = streamMetaData;
     }
 
     public static void insertFrameId(long captureTimeMs) {

--- a/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/WebSocketConstants.java
+++ b/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/WebSocketConstants.java
@@ -419,5 +419,5 @@ public class WebSocketConstants {
      * It's sent to determine mainTrackId if exists
      */
     public static final String MAIN_TRACK = "mainTrack";
-
+    public static final String META_DATA = "metaData";
 }

--- a/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/WebSocketHandler.java
+++ b/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/WebSocketHandler.java
@@ -274,7 +274,7 @@ public class WebSocketHandler implements WebSocket.WebSocketConnectionObserver {
 
     }
 
-    public void startPublish(String streamId, String token, boolean videoEnabled, boolean audioEnabled, String subscriberId, String subscriberCode, String streamName, String mainTrackId){
+    public void startPublish(String streamId, String token, boolean videoEnabled, boolean audioEnabled, String subscriberId, String subscriberCode, String streamName, String mainTrackId, String streamMetaData){
         checkIfCalledOnValidThread();
         JSONObject json = new JSONObject();
         try {
@@ -287,6 +287,7 @@ public class WebSocketHandler implements WebSocket.WebSocketConnectionObserver {
             json.put(WebSocketConstants.VIDEO, videoEnabled);
             json.put(WebSocketConstants.AUDIO, audioEnabled);
             json.put(WebSocketConstants.MAIN_TRACK, mainTrackId);
+            json.put(WebSocketConstants.META_DATA, streamMetaData);
 
             sendTextMessage(json.toString());
         } catch (JSONException e) {

--- a/webrtc-android-framework/src/test/java/io/antmedia/webrtcandroidframework/WebRTCClientTest.java
+++ b/webrtc-android-framework/src/test/java/io/antmedia/webrtcandroidframework/WebRTCClientTest.java
@@ -103,7 +103,7 @@ public class WebRTCClientTest {
 
         webRTCClient.startStream();
 
-        verify(wsHandler, times(1)).startPublish(streamId, token, videoCallEnabled, audioCallEnabled, subscriberId, subscriberCode, streamName, null);
+        verify(wsHandler, times(1)).startPublish(streamId, token, videoCallEnabled, audioCallEnabled, subscriberId, subscriberCode, streamName, null, "");
 
         ArgumentCaptor<String> jsonCaptor = ArgumentCaptor.forClass(String.class);
         verify(wsHandler, times(1)).sendTextMessage(jsonCaptor.capture());


### PR DESCRIPTION
It is extremely important for the client application to exchange metadata between participants. Sometimes the client application needs to know some public information about the participants. The implementation of "metadata" is partially implemented in the Android SDK though requires to be completed. This pull request completes the implementation of "metadata" in the "publish" command allowing Client Code to be set any type of metadata as a string

{"command":"publish","streamId":"IBsMPkTIMdxKgYdB","subscriberId":"","subscriberCode":"","streamName":"","mainTrack":"room1","video": true "audio": true "metadata": "{someKey: someValue}"}