### PR TITLE
Added an onReceiveStreamsInfo event to AntMediaSignallingEvents

### DIFF
--- a/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/AntMediaSignallingEvents.java
+++ b/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/AntMediaSignallingEvents.java
@@ -1,6 +1,7 @@
 package io.antmedia.webrtcandroidframework;
 
 
+import org.json.JSONArray;
 import org.webrtc.IceCandidate;
 import org.webrtc.SessionDescription;
 
@@ -108,4 +109,6 @@ public interface AntMediaSignallingEvents {
      * @param definition
      */
     void onError(String streamId, String definition);
+
+    void onReceiveStreamsInfo(JSONArray streamList);
 }

--- a/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/ConferenceManager.java
+++ b/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/ConferenceManager.java
@@ -6,6 +6,7 @@ import android.os.Build;
 import android.os.Handler;
 import android.util.Log;
 
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.webrtc.DataChannel;
@@ -290,6 +291,11 @@ public class ConferenceManager implements AntMediaSignallingEvents, IDataChannel
         if (publisherClient != null && !publisherClient.isStreaming()) {
             publishStream(streamId);
         }
+    }
+
+    @Override
+    public void onReceiveStreamsInfo(JSONArray streamList) {
+
     }
 
     public void switchCamera()

--- a/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/MultitrackConferenceManager.java
+++ b/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/MultitrackConferenceManager.java
@@ -9,6 +9,7 @@ import android.os.Handler;
 import android.util.Log;
 import android.view.View;
 
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.webrtc.DataChannel;
@@ -309,6 +310,11 @@ public class MultitrackConferenceManager implements AntMediaSignallingEvents, ID
         if (playWebRTCClient != null && !playWebRTCClient.isStreamStarted()) {
             playWebRTCClient.startStream();
         }
+    }
+
+    @Override
+    public void onReceiveStreamsInfo(JSONArray streamList) {
+
     }
 
     public void switchCamera()

--- a/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/WebRTCClient.java
+++ b/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/WebRTCClient.java
@@ -27,6 +27,7 @@ import android.view.View;
 import android.view.WindowManager;
 import android.widget.Toast;
 
+import org.json.JSONArray;
 import org.webrtc.AddIceObserver;
 import org.webrtc.AudioSource;
 import org.webrtc.AudioTrack;
@@ -1596,6 +1597,11 @@ public class WebRTCClient implements IWebRTCClient, AntMediaSignallingEvents, ID
 
     @Override
     public void onRoomInformation(String[] streams) {
+        //no need to implement here
+    }
+
+    @Override
+    public void onReceiveStreamsInfo(JSONArray streamList) {
         //no need to implement here
     }
 

--- a/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/WebSocketHandler.java
+++ b/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/WebSocketHandler.java
@@ -155,6 +155,10 @@ public class WebSocketHandler implements WebSocket.WebSocketConnectionObserver {
                         streams[i] = streamsArray.getString(i);
                     }
                 }
+                if (json.has(WebSocketConstants.STREAM_LIST_IN_ROOM) && !json.isNull(WebSocketConstants.STREAM_LIST_IN_ROOM)) {
+                    JSONArray streamsArray = json.getJSONArray(WebSocketConstants.STREAM_LIST_IN_ROOM);
+                    signallingListener.onReceiveStreamsInfo(streamsArray);
+                }
                 signallingListener.onRoomInformation(streams);
             }
             else if (commandText.equals(WebSocketConstants.STREAM_INFORMATION_NOTIFICATION)) {


### PR DESCRIPTION
This pull request contains the logic to read and pass the contents of the StreamList property to client code.

The Android SDK contains a comment that the "streams" property of the "roomInformation" command should not be used as it was deprecated, citing that the "streamList" property should be used, but we didn't see any place where the "streamList" property was handled somehow and would be processed in the SDK and the value of the prop passed to the client code..Hance we can not get access to "metadata" that resides inside "streamList" . The StreamList contains the metadata we need.