### PR TITLE
Set Default Value of remoteVideoRotationExtension to true

### DIFF
--- a/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/core/WebRTCClient.java
+++ b/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/core/WebRTCClient.java
@@ -212,7 +212,7 @@ public class WebRTCClient implements IWebRTCClient, AntMediaSignallingEvents {
     //PeerConnection Parameters
     private final WebRTCClientConfig config;
 
-    private boolean removeVideoRotationExtention = false;
+    private boolean removeVideoRotationExtension = true;
 
     //reconnection parameters
     private Handler reconnectionHandler = new Handler();
@@ -484,7 +484,7 @@ public class WebRTCClient implements IWebRTCClient, AntMediaSignallingEvents {
                 sdp = preferCodec(sdp, getSdpVideoCodecName(config.videoCodec), false);
             }
 
-            if(removeVideoRotationExtention) {
+            if(removeVideoRotationExtension) {
                 sdp = sdp.replace(VIDEO_ROTATION_EXT_LINE, "");
             }
 
@@ -2191,8 +2191,8 @@ public class WebRTCClient implements IWebRTCClient, AntMediaSignallingEvents {
         return videoCapturer;
     }
 
-    public void setRemoveVideoRotationExtention(boolean removeVideoRotationExtention) {
-        this.removeVideoRotationExtention = removeVideoRotationExtention;
+    public void setRemoveVideoRotationExtension(boolean removeVideoRotationExtension) {
+        this.removeVideoRotationExtension = removeVideoRotationExtension;
     }
 
     @androidx.annotation.Nullable

--- a/webrtc-android-framework/src/test/java/io/antmedia/webrtcandroidframework/WebRTCClientTest.java
+++ b/webrtc-android-framework/src/test/java/io/antmedia/webrtcandroidframework/WebRTCClientTest.java
@@ -559,15 +559,17 @@ public class WebRTCClientTest {
                 WebRTCClient.VIDEO_ROTATION_EXT_LINE +
                 "something else\r\n";
 
+        webRTCClient.setRemoveVideoRotationExtension(true);
+
         webRTCClient.getSdpObserver(streamId).onCreateSuccess(new SessionDescription(SessionDescription.Type.OFFER, fakeSdp));
         assertNotNull(webRTCClient.getLocalDescription());
-        assertTrue(webRTCClient.getLocalDescription().description.contains(WebRTCClient.VIDEO_ROTATION_EXT_LINE));
+        assertFalse(webRTCClient.getLocalDescription().description.contains(WebRTCClient.VIDEO_ROTATION_EXT_LINE));
 
 
-        webRTCClient.setRemoveVideoRotationExtention(true);
+        webRTCClient.setRemoveVideoRotationExtension(false);
         webRTCClient.getSdpObserver(streamId).onCreateSuccess(new SessionDescription(SessionDescription.Type.OFFER, fakeSdp));
 
-        assertFalse(webRTCClient.getLocalDescription().description.contains(WebRTCClient.VIDEO_ROTATION_EXT_LINE));
+        assertTrue(webRTCClient.getLocalDescription().description.contains(WebRTCClient.VIDEO_ROTATION_EXT_LINE));
 
     }
 


### PR DESCRIPTION
https://github.com/ant-media/Ant-Media-Server/issues/5970
If remoteVideoRotationExtension is false video is rotated 90 degree if abr is added on server side
this pr makes it default value to true and fixes this problem.


