### PR TITLE
add helper method to toggle audio of everybody in a call

### DIFF
--- a/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/api/IWebRTCClient.java
+++ b/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/api/IWebRTCClient.java
@@ -241,4 +241,10 @@ public interface IWebRTCClient {
      */
     void getBroadcastObject(String streamId);
 
+    /**
+     * Toggle audio for all participants in a call.
+     * If 'enabled' is true, unmutes all participants; otherwise, mutes all participants.
+     */
+    void toggleAudioOfAllParticipants(boolean enabled);
+
 }

--- a/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/core/WebRTCClient.java
+++ b/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/core/WebRTCClient.java
@@ -2178,7 +2178,7 @@ public class WebRTCClient implements IWebRTCClient, AntMediaSignallingEvents {
 
     private void drainCandidates(String streamId) {
         PeerInfo peerInfo = getPeerInfoFor(streamId);
-        if(peerInfo == null){
+        if(peerInfo == null || peerInfo.getQueuedRemoteCandidates() == null){
             return;
         }
         List<IceCandidate> queuedRemoteCandidates = peerInfo.getQueuedRemoteCandidates();

--- a/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/core/WebRTCClient.java
+++ b/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/core/WebRTCClient.java
@@ -2215,6 +2215,24 @@ public class WebRTCClient implements IWebRTCClient, AntMediaSignallingEvents {
         isInitiator = initiator;
     }
 
+    public void toggleAudioOfAllParticipants(boolean enabled) {
+
+        for (Map.Entry<String, PeerInfo> entry : peers.entrySet()) {
+            PeerConnection peerConnection = entry.getValue().peerConnection;
+            if (peerConnection != null) {
+                List<RtpReceiver> receivers = peerConnection.getReceivers();
+
+                for (RtpReceiver receiver : receivers) {
+                    MediaStreamTrack track = receiver.track();
+                    if (track != null && track.kind().equals("audio")) {
+                        AudioTrack audioTrack = (AudioTrack) track;
+                        audioTrack.setEnabled(enabled);
+                    }
+                }
+            }
+        }
+    }
+
     public void setHandler(Handler handler) {
         this.handler = handler;
     }

--- a/webrtc-android-framework/src/test/java/io/antmedia/webrtcandroidframework/WebRTCClientTest.java
+++ b/webrtc-android-framework/src/test/java/io/antmedia/webrtcandroidframework/WebRTCClientTest.java
@@ -60,6 +60,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.Timer;
@@ -1104,6 +1105,55 @@ public class WebRTCClientTest {
         webRTCClient.onBroadcastObject(broadcast);
 
         verify(listener, times(1)).onBroadcastObject(broadcast);
+    }
+
+    @Test
+    public void testToggleAudioOfAllParticipants(){
+        PeerConnection pc = mock(PeerConnection.class);
+        String streamId1 = "stream1";
+
+        List<RtpReceiver> receivers = new LinkedList<>();
+
+        when(pc.getReceivers()).thenReturn(receivers);
+
+
+        RtpReceiver receiver1 = mock(RtpReceiver.class);
+
+
+        receivers.add(receiver1);
+
+        RtpReceiver receiver2 = mock(RtpReceiver.class);
+
+        RtpReceiver receiver3 = mock(RtpReceiver.class);
+
+
+        MediaStreamTrack videoTrack = mock(VideoTrack.class);
+        MediaStreamTrack audioTrack = mock(AudioTrack.class);
+
+
+        when(receiver2.track()).thenReturn(videoTrack);
+
+        when(videoTrack.kind()).thenReturn("video");
+
+        when(receiver3.track()).thenReturn(audioTrack);
+        when(audioTrack.kind()).thenReturn("audio");
+
+        receivers.add(receiver2);
+        receivers.add(receiver3);
+
+
+        webRTCClient.addPeerConnection(streamId1, null);
+
+        webRTCClient.toggleAudioOfAllParticipants(true);
+
+        webRTCClient.addPeerConnection(streamId1, pc);
+
+        webRTCClient.toggleAudioOfAllParticipants(false);
+
+        assertFalse(audioTrack.enabled());
+
+
+
     }
 
 

--- a/webrtc-android-framework/src/test/java/io/antmedia/webrtcandroidframework/WebRTCClientTest.java
+++ b/webrtc-android-framework/src/test/java/io/antmedia/webrtcandroidframework/WebRTCClientTest.java
@@ -42,6 +42,7 @@ import org.webrtc.DataChannel;
 import org.webrtc.IceCandidate;
 import org.webrtc.IceCandidateErrorEvent;
 import org.webrtc.MediaStream;
+import org.webrtc.MediaStreamTrack;
 import org.webrtc.PeerConnection;
 import org.webrtc.PeerConnectionFactory;
 import org.webrtc.RtpParameters;


### PR DESCRIPTION
This pull request introduces a feature enabling the audio toggling for all participants within a call, particularly beneficial for the development of conference applications.

https://github.com/ant-media/Ant-Media-Server/issues/6020
