### PR TITLE
Choose Bluetooth Headphone As AudioDevice

### DIFF
--- a/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/api/IWebRTCClient.java
+++ b/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/api/IWebRTCClient.java
@@ -60,6 +60,13 @@ public interface IWebRTCClient {
     void play(String streamId);
 
     /**
+     * This is used to play a WebRTC stream
+     * @param streamId: id for the stream to play
+     * @param requestBluetoothForPlay: If true request bluetooth permission before play.
+     */
+    void play(String streamId, boolean requestBluetoothForPlay);
+
+    /**
      * This is used to play a multitrack WebRTC stream
      * @param streamId: id for the stream to play
      * @param tracks: subtracks to play in multitrack stream
@@ -68,14 +75,15 @@ public interface IWebRTCClient {
 
     /**
      * This is used to play a WebRTC stream with all parameters
-     * @param streamId: id for the stream to play
-     * @param token: token to authenticate
-     * @param tracks: subtracks to play in multitrack stream
-     * @param subscriberId: id of the subscriber
-     * @param subscriberCode: code of the subscriber
-     * @param viewerInfo: viewer info, any string is accepted
+     * @param streamId : id for the stream to play
+     * @param token : token to authenticate
+     * @param tracks : subtracks to play in multitrack stream
+     * @param subscriberId : id of the subscriber
+     * @param subscriberCode : code of the subscriber
+     * @param viewerInfo : viewer info, any string is accepted
+     * @param requestBluetoothForPlay
      */
-    void play(String streamId, String token, String[] tracks,  String subscriberId, String subscriberCode, String viewerInfo);
+    void play(String streamId, String token, String[] tracks, String subscriberId, String subscriberCode, String viewerInfo, boolean requestBluetoothForPlay);
 
     /**
      * This is used to join a peer to peer call

--- a/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/core/PermissionsHandler.java
+++ b/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/core/PermissionsHandler.java
@@ -34,11 +34,15 @@ public class PermissionsHandler {
         this.activity = activity;
     }
 
-    public boolean checkAndRequestPermisssions(boolean isExtended, PermissionCallback permissionCallback) {
+    public boolean checkAndRequestPermisssions(boolean isExtended, boolean requestBluetoothForPlay, PermissionCallback permissionCallback) {
         ArrayList<String> permissions = new ArrayList<>();
         permissions.addAll(Arrays.asList(REQUIRED_MINIMUM_PERMISSIONS));
         if(isExtended) {
             permissions.addAll(Arrays.asList(REQUIRED_EXTENDED_PERMISSIONS));
+        }
+
+        if(requestBluetoothForPlay){
+            permissions.add(Manifest.permission.BLUETOOTH_CONNECT);
         }
 
         if (hasPermissions(activity.getApplicationContext(), permissions)) {


### PR DESCRIPTION
If a Bluetooth headphone is available, select it as the audio device. If the user specifies, request permission for Bluetooth before playing.

To indicate a preference for using Bluetooth headphones if available, users should set `requestBluetoothForPlay = true` in the `.play()` call.

Currently, requesting permission on play/publish causes an ANR crash due to `waitForWSHandler()`. This issue is known and addressed in a separate PR.

In my opinion, handling permissions within the SDK is not the correct approach. We should consider moving them out of SDK. This PR maintains the current pattern and manages permissions within the SDK.

https://github.com/ant-media/Ant-Media-Server/issues/6232

