### PR TITLE
Set default audio device as speaker on P2P, switch to bluetooth device if its available

### DIFF
--- a/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/core/WebRTCClient.java
+++ b/webrtc-android-framework/src/main/java/io/antmedia/webrtcandroidframework/core/WebRTCClient.java
@@ -1081,6 +1081,10 @@ public class WebRTCClient implements IWebRTCClient, AntMediaSignallingEvents {
         peers.put(streamId, peerInfo);
 
         init();
+
+        initializeAudioManager();
+
+
         wsHandler.joinToPeer(streamId, token);
     }
 
@@ -1101,16 +1105,31 @@ public class WebRTCClient implements IWebRTCClient, AntMediaSignallingEvents {
         enableStatsEvents(streamId, true, STAT_CALLBACK_PERIOD);
     }
 
-    // This method is called when the audio manager reports audio device change,
-    // e.g. from wired headset to speakerphone.
+    /**
+     * Handles changes in audio devices reported by the audio manager, such as
+     * switching from a wired headset to a speakerphone.
+     *
+     * @param device The currently selected audio device.
+     * @param availableDevices A set of available audio devices.
+     */
     public void onAudioManagerDevicesChanged(
             final AppRTCAudioManager.AudioDevice device, final Set<AppRTCAudioManager.AudioDevice> availableDevices) {
-        Log.d(TAG, "onAudioManagerDevicesChanged: " + availableDevices + ", "
-                + "selected: " + device);
-        // TODO(henrika): add callback handler.
-        if (audioManager != null) {
-            audioManager.selectAudioDevice(device);
+        if(audioManager == null){
+            return;
         }
+        Log.i(TAG, "Audio devices changed. Available: " + availableDevices + ", Selected: " + device);
+
+        // Prioritize Bluetooth if available
+        if (availableDevices.contains(AppRTCAudioManager.AudioDevice.BLUETOOTH)) {
+            Log.i(TAG, "Bluetooth device found, switching to Bluetooth.");
+            audioManager.selectAudioDevice(AppRTCAudioManager.AudioDevice.BLUETOOTH);
+            return;
+        }
+
+        // Fallback to the current selected device
+        Log.i(TAG, "Switching to the selected device: " + device);
+        audioManager.selectAudioDevice(device);
+
     }
 
     // Disconnect from remote resources, dispose of local resources, and exit.

--- a/webrtc-android-framework/src/test/java/io/antmedia/webrtcandroidframework/WebRTCClientTest.java
+++ b/webrtc-android-framework/src/test/java/io/antmedia/webrtcandroidframework/WebRTCClientTest.java
@@ -260,11 +260,13 @@ public class WebRTCClientTest {
 
         when(context.getString(anyInt(), Matchers.<Object>anyVararg())).thenReturn("asas");
         doNothing().when(webRTCClient).init();
+        doNothing().when(webRTCClient).initializeAudioManager();
         doReturn(true).when(wsHandler).isConnected();
 
 
         webRTCClient.join(streamId, token);
 
+        verify(webRTCClient, times(1)).initializeAudioManager();
         verify(wsHandler, times(1)).joinToPeer(streamId, token);
 
         ArgumentCaptor<String> jsonCaptor = ArgumentCaptor.forClass(String.class);
@@ -410,6 +412,14 @@ public class WebRTCClientTest {
 
         // Verify that the audio device is selected using the AudioManager
         Mockito.verify(audioManager).selectAudioDevice(device);
+
+        availableDevices.clear();
+
+        availableDevices.add(AppRTCAudioManager.AudioDevice.SPEAKER_PHONE);
+        AppRTCAudioManager.AudioDevice speakerDevice = AppRTCAudioManager.AudioDevice.SPEAKER_PHONE;
+
+        webRTCClient.onAudioManagerDevicesChanged(speakerDevice, availableDevices);
+        Mockito.verify(audioManager).selectAudioDevice(speakerDevice);
     }
 
     @Test

--- a/webrtc-android-sample-app/src/main/java/io/antmedia/webrtc_android_sample_app/MainActivity.java
+++ b/webrtc-android-sample-app/src/main/java/io/antmedia/webrtc_android_sample_app/MainActivity.java
@@ -51,6 +51,8 @@ public class MainActivity extends AppCompatActivity implements AdapterView.OnIte
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        getSupportActionBar().hide();
+
         setContentView(R.layout.activity_main);
 
         list = findViewById(R.id.list);

--- a/webrtc-android-sample-app/src/main/java/io/antmedia/webrtc_android_sample_app/TestableActivity.java
+++ b/webrtc-android-sample-app/src/main/java/io/antmedia/webrtc_android_sample_app/TestableActivity.java
@@ -40,7 +40,7 @@ public abstract class TestableActivity extends AppCompatActivity {
         getWindow().addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN | WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON
                 | WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD | WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED
                 | WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON);
-        //getWindow().getDecorView().setSystemUiVisibility(getSystemUiVisibility());
+        getSupportActionBar().hide();
 
         sharedPreferences =
                 PreferenceManager.getDefaultSharedPreferences(this /* Activity context */);

--- a/webrtc-android-sample-app/src/main/res/layout/activity_main.xml
+++ b/webrtc-android-sample-app/src/main/res/layout/activity_main.xml
@@ -9,8 +9,7 @@
         android:id="@+id/list"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_marginTop="120dp"
-        android:layout_marginBottom="42dp"
+
         android:columnWidth="40dp"
         android:gravity="center"
         android:horizontalSpacing="21dp"

--- a/webrtc-android-sample-app/src/main/res/values/styles.xml
+++ b/webrtc-android-sample-app/src/main/res/values/styles.xml
@@ -1,9 +1,11 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <!-- Customize your theme here. -->
         <item name="colorPrimary">@color/colorPrimary</item>
+        <item name="windowNoTitle">true</item>
+        <item name="android:windowNoTitle">true</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
     </style>


### PR DESCRIPTION
https://github.com/ant-media/Ant-Media-Server/issues/6624

If bluetooth is enabled and bluetooth headphone is connected, it starts call with bluetooth headphone. If bluetooth headphone is disconnected during the call it switches back to speakers. If bluetooth headphone connected during call it switches to bluetooth headphone.